### PR TITLE
Fix feature demo youtube link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Here's a video explaining how it works:
 
 And here's a feature demo video (with music!) showing color RGB dithering, CMYK halftone, true 1-bit low-res effects, and much more:
 
-[![Surface-Stable Fractal Dithering Demo video on YouTube](https://img.youtube.com/vi/EzjWBmhO_1E/0.jpg)](https://www.youtube.com/watch?v=HPqGaIMVuLs)
+[![Surface-Stable Fractal Dithering Demo video on YouTube](https://img.youtube.com/vi/EzjWBmhO_1E/0.jpg)](https://www.youtube.com/watch?v=EzjWBmhO_1E)
 
 This repository contains the shader and texture source files, and a Unity example project demonstrating their use. The example project is made with Unity 2019.4 and is also tested in Unity 2022.3 and Unity 6. It's based on the Forward rendering path in the Built-in Render Pipeline.
 


### PR DESCRIPTION
The preview image was correct, but the actual youtube link was to the other video